### PR TITLE
добавлены локеры для thread-safe кэша  Dictionary<string, string>

### DIFF
--- a/DataPlatformAnalytics/Core/Cache/FileEventCache.cs
+++ b/DataPlatformAnalytics/Core/Cache/FileEventCache.cs
@@ -44,21 +44,31 @@ namespace SberGames.DataPlatform.Core
 
         public void Add(string evetnId, string eventData)
         {
-            cache.Add(evetnId, eventData);
+            lock (cache)
+            {
+                cache.Add(evetnId, eventData);
+            }
+
             cacheWriter.WriteLine(evetnId + Delimiter + eventData);
             currentCacheFileUnsentEventCount++;
         }
 
         public void Remove(string eventId)
         {
-            cache.Remove(eventId);
+            lock (cache)
+            {
+                cache.Remove(eventId);
+            }
             sentWriter.WriteLine(eventId);
             currentCacheFileUnsentEventCount--;
         }
 
         public IEnumerable<KeyValuePair<string, string>> UnsentEvents()
         {
-            return cache;
+            lock (cache)
+            {
+                return cache;
+            }
         }
         
         public void Dispose()


### PR DESCRIPTION
Решения проблемы редкого вылета из-за обращения к кэш-словарю. 
В в методе **public void Add(string evetnId, string eventData)** класса **FileEventCache**
Добавлены локеры для thread-safe кэша  Dictionary<string, string>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sbergames/unity-shared-packages/9)
<!-- Reviewable:end -->
